### PR TITLE
Update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,10 @@
 version: 2
 
+version: 2
+mkdocs:
+  # Path to your MkDocs configuration file.
+  configuration: mkdocs.yml
+  
 python:
   install:
     - requirements: source/rtd_requirements.txt


### PR DESCRIPTION
Adding 
version: 2
mkdocs:
  # Path to your MkDocs configuration file.
  configuration: mkdocs.yml

According to:
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/