### PR TITLE
Update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,8 +1,7 @@
 version: 2
-
 sphinx:
   # Path to your Sphinx configuration file.
-  configuration: docs/.travis.yml
+  configuration: docs/conf.py
   
 python:
   install:


### PR DESCRIPTION
According to:
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/